### PR TITLE
[Resub] Fix 2493, 2933: Side Menu Issue Fix

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -1,10 +1,10 @@
 <template>
-  <div ref="Side" class="SideNavigation" tabindex="-1">
+  <v-sheet ref="Side" class="SideNavigation">
     <header class="SideNavigation-Header">
       <v-icon
         class="SideNavigation-OpenIcon"
         :aria-label="$t('サイドメニュー項目を開く')"
-        @click="$emit('openNavi', $event)"
+        @click.stop="isWindowSizeConsole()"
       >
         mdi-menu
       </v-icon>
@@ -24,11 +24,21 @@
       </h1>
     </header>
 
-    <div :class="['SideNavigation-Body', { '-opened': isNaviOpen }]">
+    <v-navigation-drawer
+      v-model="drawer"
+      tabindex="-1"
+      class="SideNavigation-Body"
+      hide-overlay
+      touchless
+      stateless
+      floating
+      tag="div"
+      width="inherit"
+    >
       <v-icon
         class="SideNavigation-CloseIcon"
         :aria-label="$t('サイドメニュー項目を閉じる')"
-        @click="$emit('closeNavi', $event)"
+        @click.stop="isWindowSizeConsole()"
       >
         mdi-close
       </v-icon>
@@ -42,10 +52,14 @@
             <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
               {{ $t('多言語対応選択メニュー') }}
             </label>
-            <language-selector />
+            <LanguageSelector />
           </div>
         </div>
-        <menu-list :items="items" @click="$emit('closeNavi', $event)" />
+        <menu-list
+          :items="items"
+          @click="isWindowSizeConsole()"
+          @blur="this.$refs.MainPage.focus()"
+        />
       </nav>
 
       <footer class="SideNavigation-Footer">
@@ -110,8 +124,8 @@
           2020 Tokyo Metropolitan Government
         </small>
       </footer>
-    </div>
-  </div>
+    </v-navigation-drawer>
+  </v-sheet>
 </template>
 
 <script lang="ts">
@@ -136,6 +150,25 @@ export default Vue.extend({
     isNaviOpen: {
       type: Boolean,
       required: true
+    },
+    maxMobileWidth: {
+      type: Number,
+      default: 1264
+      // Need to be correspondent to an agreed value across the project
+      // TODO: Import variables.scss so that one source can only be kept up
+    },
+    temporary: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data(): {
+    drawer: boolean | null
+    screenWidth: Number
+  } {
+    return {
+      drawer: null,
+      screenWidth: 0
     }
   },
   computed: {
@@ -149,13 +182,7 @@ export default Vue.extend({
         {
           icon: 'CovidIcon',
           title: this.$t('新型コロナウイルス感染症が心配なときに'),
-          link: this.localePath('/flow')
-        },
-        {
-          icon: 'CovidIcon',
-          title: this.$t('新型コロナウイルスの感染が判明した方へ'),
-          link:
-            'https://www.fukushihoken.metro.tokyo.lg.jp/oshirase/corona_0401.html',
+          link: this.localePath('/flow'),
           divider: true
         },
         {
@@ -178,11 +205,6 @@ export default Vue.extend({
           title: this.$t('東京都新型コロナウイルス感染症対策本部報'),
           link:
             'https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/index.html'
-        },
-        {
-          title: this.$t('新型コロナウイルス感染症に関する東京都の支援策'),
-          link:
-            'https://www.seisakukikaku.metro.tokyo.lg.jp/information/corona-support.html'
         },
         {
           title: this.$t('東京都主催等 中止又は延期するイベント等'),
@@ -212,15 +234,39 @@ export default Vue.extend({
   watch: {
     $route: 'handleChageRoute'
   },
+  mounted() {
+    this.$nextTick().then(() => {
+      window.addEventListener('resize', this.getWindowWidth, false)
+      window.addEventListener('orientationchange', this.getWindowWidth, false)
+      this.isWindowSizeConsole()
+    })
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.getWindowWidth, false)
+    window.removeEventListener('orientationchange', this.getWindowWidth, false)
+  },
   methods: {
     handleChageRoute() {
-      // nuxt-link で遷移するとフォーカスが残り続けるので $route を監視して SideNavigation にフォーカスする
-      return this.$nextTick().then(() => {
+      // nuxt-link で遷移するとフォーカスが残り続けるので
+      // $route を監視して SideNavigation にフォーカスする
+      this.$nextTick().then(() => {
         const $Side = this.$refs.Side as HTMLEmbedElement | undefined
         if ($Side) {
           $Side.focus()
         }
       })
+    },
+    getWindowWidth() {
+      this.screenWidth = document.documentElement.clientWidth
+        ? document.documentElement.clientWidth
+        : screen
+        ? screen.width
+        : window
+        ? window.innerWidth
+        : 0
+    },
+    isWindowSizeConsole() {
+      this.drawer = this.screenWidth < this.maxMobileWidth ? !this.drawer : true
     }
   }
 })
@@ -229,9 +275,11 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .SideNavigation {
   position: relative;
+
   @include lessThan($small) {
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.15);
   }
+
   &:focus {
     outline: 1px dotted $gray-3;
   }
@@ -244,9 +292,11 @@ export default Vue.extend({
     height: auto;
     padding: 20px;
   }
+
   @include lessThan($small) {
     display: flex;
   }
+
   @include lessThan($tiny) {
     padding-left: 44px;
   }
@@ -262,6 +312,7 @@ export default Vue.extend({
     font-size: 24px;
     padding: 20px 10px;
   }
+
   @include largerThan($small) {
     display: none;
   }
@@ -271,12 +322,14 @@ export default Vue.extend({
   position: absolute;
   top: 0;
   left: 0;
-  padding: 18px 8px 18px 16px;
+  padding: 18px 8px 18px 32px;
   font-size: 28px;
+
   @include lessThan($tiny) {
     font-size: 24px;
     padding: 20px 10px;
   }
+
   @include largerThan($small) {
     display: none;
   }
@@ -286,6 +339,7 @@ export default Vue.extend({
   width: 100%;
   font-size: 13px;
   color: #707070;
+
   @include largerThan($small) {
     margin: 0;
     margin-top: 10px;
@@ -296,12 +350,15 @@ export default Vue.extend({
   display: flex;
   align-items: center;
   padding-right: 10px;
+
   @include lessThan($small) {
     height: 64px;
   }
+
   @include lessThan($tiny) {
     justify-content: space-between;
   }
+
   &:link,
   &:hover,
   &:focus,
@@ -334,6 +391,7 @@ export default Vue.extend({
 
 .SideNavigation-HeaderText {
   margin: 10px 0 0 0;
+
   @include lessThan($small) {
     margin: 0 0 0 10px;
   }
@@ -345,23 +403,49 @@ export default Vue.extend({
 
 .SideNavigation-Body {
   padding: 0 20px 20px;
+
   @include lessThan($small) {
-    display: none;
     padding: 0 36px 36px;
-    &.-opened {
-      position: fixed;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      display: block !important;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    display: block !important;
+    background-color: $white;
+    height: 100%;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+
+    & .v-navigation-drawer {
+      z-index: 0;
       width: 100%;
-      z-index: z-index-of(opened-side-navigation);
-      background-color: $white;
-      height: 100%;
-      overflow: auto;
-      -webkit-overflow-scrolling: touch;
     }
   }
+
+  @include largerThan($small) {
+    & .v-navigation-drawer {
+      z-index: 6;
+      visibility: visible;
+      width: inherit;
+      height: 100%;
+    }
+  }
+
+  &
+    .v-navigation-drawer--is-mobile:not(.v-navigation-drawer--close)
+    + .v-navigation-drawer__content {
+    visibility: visible;
+  }
+
+  &
+    .v-navigation-drawer--is-mobile::after(.v-navigation-drawer--close)
+    + .v-navigation-drawer__content {
+    visibility: hidden;
+  }
+}
+
+.v-navigation-drawer--bottom.v-navigation-drawer--is-mobile {
+  min-width: inherit;
 }
 
 .SideNavigation-Menu {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->
※ PR の再サブミットになります。
## 👏 解決する issue / Resolved Issues
- close #2493 
- close #2933 

## 📝 関連する issue / Related Issues
- #2878 
- #2935 
- #2841 （未反映、ただし要望があれば速やかに実装可能）

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- (EN) Apply v-navigation-drawer mechanism, plus tabstop="-1" refinement
- (JA) v-navigation-drawer 機能の適用、および tabstop="-1" の見直し
- (EN) Expect improved maintainability using a common Vuetify platform
- (JA) Vuetify という共通プラットフォームに使用による、メンテナンス性の向上

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
[(EN) On a mobile screen, suppress a dotted border line b/w header and body]
[(JA) iPhone の画面切替時、ヘッダの下の破線を出なくする]
![iPhone](https://user-images.githubusercontent.com/10361533/80109721-c7283880-85b8-11ea-8713-759d739fde42.gif)

[(EN) Smoothen language menu switch on Chrome]
[(JA) Chrome 上における、言語メニューの切替をスムーズにする
![Chrome](https://user-images.githubusercontent.com/10361533/80109994-27b77580-85b9-11ea-84bf-4f288c754c9c.gif)
]
